### PR TITLE
added missing objref in Print-to-File.hoc

### DIFF
--- a/Fig6_IO_burst_PSP_GABA_rectification.hoc
+++ b/Fig6_IO_burst_PSP_GABA_rectification.hoc
@@ -9,10 +9,10 @@ objref storeM_slow, storeM_noRect, storeM_onlyRect, storeM_partRect
 load_file("Print-to-File.hoc")
 
 ColLabel = "Membrane potential"
-file_name1="C:/../Inh_slow.atf"
-file_name2="C:/../Inh_noRect.atf"
-file_name3="C:/../Inh_onlyRect.atf"
-file_name4="C:/../Inh_partRect.atf"
+file_name1="Inh_slow.atf"
+file_name2="Inh_noRect.atf"
+file_name3="Inh_onlyRect.atf"
+file_name4="Inh_partRect.atf"
 
 // Numerical parameters for simulation.
 tstop = 300 // stop time of simulation
@@ -194,10 +194,9 @@ for(jj=1; jj<simul_iter+1; jj=jj+1){
     if (jj%2==1){graphList[0].remove(curGr-1)    }    
     ncGABA[1].weight = GABAweight1
 }
-/*
+
 // SAVE OUTPUT
 print2file(storeM_slow,file_name1,ColLabel)
 print2file(storeM_noRect,file_name2,ColLabel)
 print2file(storeM_onlyRect,file_name3,ColLabel)
 print2file(storeM_partRect,file_name4,ColLabel)
-*/

--- a/Fig7_IO_burst_PSP_GABA_kinetics.hoc
+++ b/Fig7_IO_burst_PSP_GABA_kinetics.hoc
@@ -9,13 +9,13 @@ objref storeM_slow, storeM_fast, storeM_fastnorm, storeM_AMPA, storeM_slow_AMPA,
 load_file("Print-to-File.hoc")
 
 ColLabel = "Membrane potential"
-file_name1="C:/../AMPA_no_Inh.atf"
-file_name2="C:/../AMPA_Inh_slow.atf"
-file_name3="C:/../AMPA_Inh_fast.atf"
-file_name4="C:/../AMPA_Inh_fastnorm.atf"
-file_name5="C:/../Inh_slow.atf"
-file_name6="C:/../Inh_fast.atf"
-file_name7="C:/../Inh_fastnorm.atf"
+file_name1="AMPA_no_Inh.atf"
+file_name2="AMPA_Inh_slow.atf"
+file_name3="AMPA_Inh_fast.atf"
+file_name4="AMPA_Inh_fastnorm.atf"
+file_name5="Inh_slow.atf"
+file_name6="Inh_fast.atf"
+file_name7="Inh_fastnorm.atf"
 
 
 // Numerical parameters for simulation.
@@ -266,7 +266,7 @@ for(jj=1; jj<simul_iter+1; jj=jj+1){
     synGABA[1].tau2 = GABAtau2
     ncGABA[1].weight = GABAweight1
 }
-/*
+
 // save output to file
 print2file(storeM_AMPA,file_name1,ColLabel)
 print2file(storeM_slow_AMPA,file_name2,ColLabel)
@@ -275,4 +275,3 @@ print2file(storeM_fastnorm_AMPA,file_name4,ColLabel)
 print2file(storeM_slow,file_name5,ColLabel)
 print2file(storeM_fast,file_name6,ColLabel)
 print2file(storeM_fastnorm,file_name7,ColLabel)
-*/

--- a/Print-to-File.hoc
+++ b/Print-to-File.hoc
@@ -7,8 +7,9 @@
 print "Exit with CTRL D"
 
 //load_file("nrngui.hoc")
-load_file("C:/Daten/Modeling/Alpha5_NMDA_single_comp/shared/ATF.hoc") 
+load_file("shared/ATF.hoc") 
 
+objref outfile
 
 proc print2file(){ 	//print vectors into file
 	outfile = new ATF_File($s2) //has to be a string, can include address for subfolders


### PR DESCRIPTION
I added a missing objref declaration in the Print-to-File.hoc which then allowed data files to be written (once the filenames were adjusted to remove the windows specific C:/'s and the print2file() function calls were uncommented).